### PR TITLE
fix: 修正插件配置选项中ignore的函数形式的处理逻辑

### DIFF
--- a/packages/vite-plugin-mock/src/createMockServer.ts
+++ b/packages/vite-plugin-mock/src/createMockServer.ts
@@ -138,7 +138,6 @@ function createWatch(opt: ViteMockOptions, config: ResolvedConfig) {
   })
 }
 
-
 // clear cache
 function cleanRequireCache(opt: ViteMockOptions) {
   if (typeof require === 'undefined' || !require.cache) {
@@ -151,7 +150,6 @@ function cleanRequireCache(opt: ViteMockOptions) {
     }
   })
 }
-
 
 function parseJson(req: IncomingMessage): Promise<Recordable> {
   return new Promise((resolve) => {
@@ -194,7 +192,7 @@ async function getMockConfig(opt: ViteMockOptions, config: ResolvedConfig) {
         return true
       }
       if (isFunction(ignore)) {
-        return ignore(item)
+        return !ignore(item)
       }
       if (isRegExp(ignore)) {
         return !ignore.test(path.basename(item))


### PR DESCRIPTION
在使用插件时，配置选项的ignore属性的函数形式与正则形式的处理逻辑相反，且函数形式的处理逻辑不符合ignore选项语义，修改后，保证两种形式的ignore处理逻辑统一且语义相符

fix: #125 