### PR TITLE
build: remove repetition config item

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,7 +9,6 @@ module.exports = {
   extends: [
     'eslint:recommended',
     'plugin:@typescript-eslint/recommended',
-    'plugin:@typescript-eslint/recommended',
     'prettier',
   ],
   parser: '@typescript-eslint/parser',


### PR DESCRIPTION
the `plugin:@typescript-eslint/recommended` is repetition and only keep one is enough