### PR TITLE
fix: compatible with post request form data acquisition (#135)

### DIFF
--- a/packages/vite-plugin-mock/package.json
+++ b/packages/vite-plugin-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-mock",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "A mock plugin for vite",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",

--- a/packages/vite-plugin-mock/src/createMockServer.ts
+++ b/packages/vite-plugin-mock/src/createMockServer.ts
@@ -153,23 +153,29 @@ function cleanRequireCache(opt: ViteMockOptions) {
 
 function parseJson(req: IncomingMessage): Promise<Recordable> {
   return new Promise((resolve) => {
-    let body = ''
-    let jsonStr = ''
+    let jsonStr: Recordable = {}
+    let str = ''
     req.on('data', function (chunk) {
-      body += chunk
+      str += chunk
     })
-    req.on('end', function () {
+    req.on('end', () => {
       try {
-        jsonStr = JSON.parse(body)
-      } catch (err) {
-        jsonStr = ''
+        // json
+        jsonStr = JSON.parse(str)
+      } catch (e) {
+        // x-www-form-urlencoded
+        const params = new URLSearchParams(str)
+        const body: Recordable = {}
+        params.forEach((value, key) => {
+          body[key] = value
+        })
+        jsonStr = body
       }
-      resolve(jsonStr as any)
+      resolve(jsonStr)
       return
     })
   })
 }
-
 // load mock .ts files and watch
 async function getMockConfig(opt: ViteMockOptions, config: ResolvedConfig) {
   const { absConfigPath, absMockPath } = getPath(opt)


### PR DESCRIPTION
您好，我在使用您的npm包时发现，当请求头为‘x-www-form-urlencoded’时，无法在response对应的函数中，获取req.body；而请求头为‘application/json’时可以正常使用。于是我查看了您代码中关于获取body的部分（即parseJson），并且做了一些改动以此来兼容表单和json两种格式的情况。我打包自测过了，希望可以采纳。

Hello, I found when using your npm package that when the request header is 'x-www-form-urlencoded', req.body cannot be obtained in the function corresponding to response; and the request header is 'application/json' can be used normally. So I checked the part of your code about getting the body (i.e. parseJson), and made some changes to be compatible with both form and json formats. I packaged it and tested it myself, I hope it can be adopted.